### PR TITLE
update mule.yml, enable galaxy unit

### DIFF
--- a/tasks/mule.yml
+++ b/tasks/mule.yml
@@ -11,5 +11,5 @@
 
 - name: Enable Galaxy Unit
   systemd:
-    name: galaxy.service
+    name: {{ galaxy_systemd_unit_name }}.service
     enabled: yes


### PR DESCRIPTION
i believe that the var name: should also be enabled through the galaxy_systemd_unit_name var. 
If incorrect please remove merge request